### PR TITLE
Reset the indent level before parse

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -577,6 +577,7 @@ errors[13] = "Invalid Argument type to "
 errors[14] = "End of File encountered, unterminated regular expression"
 
 var compile = function(code, filename) {
+  indent = -indentSize
   var tree = parse(code, filename)
   return banner + handleExpressions(tree)
 }


### PR DESCRIPTION
Fixes #39.

This affects the REPL. Not resetting the indent level meant that the
parse function used the indent level that remained after a possible
error situation.
