### PR TITLE
Adding parseWithSourceMap method

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -762,3 +762,11 @@ if (withSourceMap) {
 exports.version = version
 
 exports._compile = _compile
+
+exports.parseWithSourceMap = function(code, filename) {
+  var tree = parse(code, filename)
+  var outputNode = handleExpressions(tree)
+  outputNode.prepend(banner)
+
+  return outputNode.toStringWithSourceMap();
+}


### PR DESCRIPTION
Adding a parse function that exposes the `SourceMapGenerator` so that inline source code comments can be used.

This change allows me to publish [lispyscriptify](https://github.com/TehShrike/lispyscriptify), a Browserify transform for Lispyscript code.