### PR TITLE
correct incorrect path with npm test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "underscore": "^1.8.2"
   },
   "scripts": {
-    "test": "lispy test/test.ls && node test/test.js",
-    "prepublish": "lispy src/lispy.ls lib/lispy.js && lispy src/repl.ls lib/repl.js && lispy src/require.ls lib/require.js && browserify -t brfs lib/browser.js > lib/browser-bundle.js && lispy test/test.ls"
+    "test": "lispy test/test.ls test/test.js && node test/test.js",
+    "prepublish": "lispy src/lispy.ls lib/lispy.js && lispy src/repl.ls lib/repl.js && lispy src/require.ls lib/require.js && browserify -t brfs lib/browser.js > lib/browser-bundle.js && lispy test/test.ls test/test.js"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
this corrects a small problem in the changes I made for "npm test" and "npm prepublish".

the lispy command generates it's output in the current directory not the directory where the source ".ls" resides, but I'd neglected to use the two argument form of "lispy" and so specify "test/" as the output dir when building the tests.

This means those commands were not updating the test/test.js file and "npm test" could actually miss (in theory) running newly added tests that way.

sorry about this 