### PR TITLE
ES6 keyword support: const & let

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -443,7 +443,8 @@ keywords["var"] = function(arr) {
     }
     handleSubExpressions(arr)
     var ret = new SourceNode ()
-    ret.add("var ")
+    var token = arr[0].name + ' '
+    ret.add(token)
 
     for (var i = 1; i < arr.length; i = i + 2) {
         if (i > 1) {
@@ -457,6 +458,8 @@ keywords["var"] = function(arr) {
     }
     return ret
 }
+keywords["const"] = keywords["var"];
+keywords["let"] = keywords["var"];
 
 keywords["new"] = function(arr) {
     if (arr.length < 2) handleError(0, arr._line, arr._filename)


### PR DESCRIPTION
These keywords have same syntax with var and should work well with same token parsing.

```
((function ()
  'use strict'
  (let a 1)
  (const b 2)
  (var c 3)))

=>

(function() {
    'use strict';
    let a = 1;
    const b = 2;
    var c = 3;
})();
```
